### PR TITLE
Fix data-src when lazyVideo is off

### DIFF
--- a/site/plugins/oembed/oembed.php
+++ b/site/plugins/oembed/oembed.php
@@ -120,8 +120,9 @@ function oembed_convert($text, $customParameters = array()) {
             'showRelated' => false
           ]);
         endif;
-
-        $htmlEmbed = str_replace(' src="', ' data-src="', $htmlEmbed);
+        
+        if (c::get('oembed.lazyvideo', false))
+          $htmlEmbed = str_replace(' src="', ' data-src="', $htmlEmbed);
 
       else:
         $htmlEmbed = $oEmbed->html;


### PR DESCRIPTION
Videos aren't displayed when lazyVideo is off because there is no `src` attribute.